### PR TITLE
fix: Add per-field serde defaults to Colors for partial config support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ confyg = "0.3.0"
 dotenvy = "0.15"
 envy = "0.4"
 serde_json = "1.0"
+toml = "0.9"
 
 [[example]]
 name = "colour-caller"

--- a/src/color.rs
+++ b/src/color.rs
@@ -1033,11 +1033,13 @@ mod tests {
         // Test that deserializing a partial Colors config preserves defaults for unspecified fields
         // This is the key fix: per-field #[serde(default)] ensures missing fields get defaults
 
-        let json = r#"{
-            "timestamp": { "fg": "HiBlack", "bg": "Reset" }
-        }"#;
+        let toml = r#"
+            [timestamp]
+            fg = "HiBlack"
+            bg = "Reset"
+        "#;
 
-        let colors: Colors = serde_json::from_str(json).expect("Failed to deserialize");
+        let colors: Colors = toml::from_str(toml).expect("Failed to deserialize");
 
         // Specified field should use config value
         assert_eq!(colors.timestamp, Some(Color::new(ColorAttribute::HiBlack, ColorAttribute::Reset)));

--- a/src/color.rs
+++ b/src/color.rs
@@ -1042,14 +1042,37 @@ mod tests {
         let colors: Colors = toml::from_str(toml).expect("Failed to deserialize");
 
         // Specified field should use config value
-        assert_eq!(colors.timestamp, Some(Color::new(ColorAttribute::HiBlack, ColorAttribute::Reset)));
+        assert_eq!(
+            colors.timestamp,
+            Some(Color::new(ColorAttribute::HiBlack, ColorAttribute::Reset))
+        );
 
         // Unspecified fields should use defaults (not None!)
-        assert_eq!(colors.level_info, Some(Color::hi_green()), "level_info should have default");
-        assert_eq!(colors.level_error, Some(Color::red()), "level_error should have default");
-        assert_eq!(colors.message, Some(Color::green()), "message should have default");
-        assert_eq!(colors.arrow, Some(Color::cyan()), "arrow should have default");
-        assert_eq!(colors.target, Some(Color::hi_yellow()), "target should have default");
+        assert_eq!(
+            colors.level_info,
+            Some(Color::hi_green()),
+            "level_info should have default"
+        );
+        assert_eq!(
+            colors.level_error,
+            Some(Color::red()),
+            "level_error should have default"
+        );
+        assert_eq!(
+            colors.message,
+            Some(Color::green()),
+            "message should have default"
+        );
+        assert_eq!(
+            colors.arrow,
+            Some(Color::cyan()),
+            "arrow should have default"
+        );
+        assert_eq!(
+            colors.target,
+            Some(Color::hi_yellow()),
+            "target should have default"
+        );
 
         // All fields should be Some
         assert!(colors.level_trace.is_some());


### PR DESCRIPTION
## Problem

When users specify `[logging.colors]` in their TOML config with only some fields (e.g., just `timestamp`), serde would deserialize ALL fields of the `Colors` struct. Unspecified fields would be set to `None` instead of using the struct's `Default` implementation values.

This caused twyg to lose colored output for all unspecified color fields.

### Example of Broken Behavior

Config file:
```toml
[logging.colors]
timestamp = { fg = "HiBlack", bg = "Reset" }
```

**Before this fix:**
- `timestamp`: `Some(HiBlack)` ✅ (from config)
- `level_info`: `None` ❌ (should be `HiGreen`)
- `message`: `None` ❌ (should be `Green`)  
- All other 11 fields: `None` ❌

Result: Only timestamps were colored, all other log output was plain white text.

## Solution

Add `#[serde(default = "default_fn")]` attribute to each field in the `Colors` struct, with corresponding default functions. This makes serde apply per-field defaults when fields are missing from the config.

**After this fix:**
- `timestamp`: `Some(HiBlack)` ✅ (from config)
- `level_info`: `Some(HiGreen)` ✅ (from default)
- `message`: `Some(Green)` ✅ (from default)
- All other fields: `Some(...)` ✅ (from defaults)

Result: Users can now customize individual colors while keeping defaults for everything else.

## Changes

1. Added `#[serde(default = "default_*")]` to all 13 fields in `Colors` struct
2. Added 13 default functions (`default_timestamp`, `default_level_info`, etc.) matching values from `Colors::default()`
3. Added test `test_colors_partial_deserialization_preserves_defaults` to verify the fix

## Testing

- ✅ All existing tests pass (147 unit tests + 15 integration tests + 10 doc tests)
- ✅ New test confirms partial config deserialization works correctly
- ✅ Verified with burrow project using twyg (real-world usage)

## Example Usage

Users can now do this in their config:

```toml
[logging.colors]
# Only customize timestamp - all other colors use twyg defaults
timestamp = { fg = "HiBlack", bg = "Reset" }
```

Or this:

```toml
[logging.colors]
# Customize a few colors
timestamp = { fg = "HiBlack", bg = "Reset" }
level_error = { fg = "HiRed", bg = "Reset" }
arrow = { fg = "HiMagenta", bg = "Reset" }
# All other fields automatically use defaults
```

## Breaking Changes

None. This is a pure bug fix that makes partial configuration work as users would naturally expect.