### PR TITLE
Add per-module log level filtering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,28 @@ pub use timestamp::TSFormat;
 /// * `report_caller`: setting to true will output the filename and line number
 ///   where the logging call was made
 /// * `time_format`: custom time format string (chrono format)
+/// * `module_filters`: per-module log level overrides (see below)
 ///
 /// With the options set, call the setup function, passing the opts as the argument.
+///
+/// # Per-Module Log Level Filtering
+///
+/// You can suppress noisy third-party crates while keeping verbose logging for
+/// your own code using `module_filter()`:
+///
+/// ```rust
+/// use twyg::{self, LogLevel, OptsBuilder};
+///
+/// let opts = OptsBuilder::new()
+///     .level(LogLevel::Trace)
+///     .module_filter("tokenizers", LogLevel::Warn)
+///     .module_filter("hyper", LogLevel::Info)
+///     .build()
+///     .unwrap();
+/// ```
+///
+/// Module filters match against the log record's target (module path) by prefix.
+/// The first matching prefix wins. Unmatched modules use the global `level`.
 ///
 /// # Structured Logging Support
 ///


### PR DESCRIPTION
## Summary

- Add `module_filters` field to `Opts` and `OptsBuilder` for per-module log level overrides
- Module filters match log record targets by prefix; first matching prefix wins
- Unmatched modules fall back to the global `level`
- `log::set_max_level()` set to the most permissive level across global + all filters so messages reach the custom `enabled()` check

### Example usage

```rust
let opts = OptsBuilder::new()
    .level(LogLevel::Trace)
    .module_filter("tokenizers", LogLevel::Warn)
    .module_filter("hyper", LogLevel::Info)
    .build()
    .unwrap();
```

This suppresses `tokenizers` TRACE/DEBUG/INFO while keeping TRACE for everything else.

## Files changed

| File | Changes |
|------|---------|
| `src/opts.rs` | `module_filters` field on `Opts` + `OptsBuilder`, accessor, builder methods, serde support, 5 new tests |
| `src/logger.rs` | `module_filters` on `LoggerConfig`, per-module filtering in `enabled()`, effective max level in `dispatch()`, 5 new tests |
| `src/lib.rs` | Updated `setup()` doc comment with module_filters example |

## Test plan

- [x] All 156 unit tests pass
- [x] All 15 integration tests pass
- [x] All 12 doc tests pass (2 new)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual verification with a program that sets `level=Trace, module_filters=[("tokenizers", Warn)]`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)